### PR TITLE
clippy whitelisted tx vs rx

### DIFF
--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -3,8 +3,6 @@
 #![feature(box_syntax)]
 #![feature(type_macros)]
 #![cfg_attr(feature = "dev", allow(unstable_features))]
-// We need this since rx_cores and tx_cores triggers a similar names warning.
-#![cfg_attr(feature = "dev", allow(similar_names))]
 // Need this since PMD port construction triggers too many arguments.
 #![cfg_attr(feature = "dev", allow(too_many_arguments))]
 #![cfg_attr(feature = "dev", feature(plugin))]


### PR DESCRIPTION
no need to allow(similar_names)